### PR TITLE
Fix typo preventing recipe info from displaying

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -2,7 +2,7 @@ import './css/base.scss';
 import './css/styles.scss';
 
 import recipeData from './data/recipes';
-import ingredientData from './data/ingredients';
+import ingredientsData from './data/ingredients';
 import users from './data/users';
 
 import Pantry from './pantry';


### PR DESCRIPTION
## Is this a fix or a feature?

-Fix

## What is the change?

-Line 5 of script.js had a typo. ingredientData was missing an s.

## What does it fix?

-This fixes the functionality of clicking on a recipe card. The recipe information is now able to display after this fix. 

## Where should the reviewer start?

- Line 5 of script.js file.

## How should this be tested?

-check functionality on the application by clicking a card to see if recipe information is dispalyed.